### PR TITLE
Fix _getInput return type

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -500,7 +500,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
     /**
      * {@inheritDoc}
      */
-    protected function _getInput(string $fieldName, array $options = []): string {
+    protected function _getInput(string $fieldName, array $options = []) {
         $label = $options['labelOptions'];
         switch (strtolower($options['type'])) {
             case 'inlineradio':


### PR DESCRIPTION
`FormHelper::_getInput()` actually has a special case where it returns an array for checkboxes (see PHPDoc of the base class):

```
     * @return string|array The generated input element string
     *  or array if checkbox() is called with option 'hiddenField' set to '_split'.
```